### PR TITLE
Fix image width

### DIFF
--- a/src/routes/panel/+page.svelte
+++ b/src/routes/panel/+page.svelte
@@ -1232,6 +1232,7 @@
                         <img
                             src={`${ProjectApi.OriginApiUrl}/api/v1/projects/getproject?projectID=${lastSelectedProjectId}&requestType=thumbnail`}
                             alt="Project Thumbnail"
+                            style={{ maxWidth: '100%' }} 
                         />
                     </a>
                 {/if}


### PR DESCRIPTION
Fix the image width in the panel

**Before:**
<img width="739" alt="Screenshot 2024-11-23 at 5 16 12 PM" src="https://github.com/user-attachments/assets/b726e2cb-22a1-44b5-bceb-9ef97adf6045">

**After:**
<img width="787" alt="Screenshot 2024-11-23 at 5 16 59 PM" src="https://github.com/user-attachments/assets/70745eb9-0eb2-43e2-b523-e50ad1b4313b">
