### PR TITLE
change invite link from NZ9MBMYTZh to vanity url (gg/penguinmod)

### DIFF
--- a/src/resources/urls.js
+++ b/src/resources/urls.js
@@ -79,7 +79,7 @@ export default {
     /**
      * PenguinMod's Discord invite
      */
-    discord: "https://discord.gg/NZ9MBMYTZh",
+    discord: "https://discord.gg/penguinmod",
 
     /**
      * Scratch's website


### PR DESCRIPTION
why was it NEVER the vanity link and https://discord.com/invite/NZ9MBMYTZh? its annoying